### PR TITLE
Ensure log file are present before tailing them

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -16,6 +16,7 @@ if [ ! -f /.riak_password_set ]; then
 fi
 
 # Print riak logs to stdout
+touch /var/log/riak/{console,crash,error}.log
 tail -F /var/log/riak/*.log &
 
 fg %1


### PR DESCRIPTION
This fixes the error

```
tail: cannot open '/var/log/riak/*.log' for reading: No such file or directory
```

that often occured due to the log files not being present when tail was started.
